### PR TITLE
Fix branch cleanup to check all commits in branch

### DIFF
--- a/functions/git-bclean.fish
+++ b/functions/git-bclean.fish
@@ -168,9 +168,10 @@ function git-bclean --description "Clean up local branches that have been merged
 
         printf "  Checking: %s " $branch
 
-        # Check if branch is merged to upstream
+        # Check if all commits from the branch exist in upstream
         set -l is_merged false
-        if git merge-base --is-ancestor $branch $upstream_branch 2>/dev/null
+        set -l branch_commits (git rev-list $branch --not $upstream_branch ^-1 2>/dev/null)
+        if test -z "$branch_commits"
             set is_merged true
             printf "✓ (merged)\n"
         else


### PR DESCRIPTION
Replace git merge-base check with git rev-list to better detect merged branches
in repositories using CI/CD pipelines. The new approach checks if all commits
from a branch exist in the upstream branch, regardless of merge strategy.
