### PR TITLE
fix(worktree): verify merges against origin/HEAD; fix git-wclean --dry-run and timeout

### DIFF
--- a/functions/git-wclean.fish
+++ b/functions/git-wclean.fish
@@ -478,11 +478,14 @@ function _wclean_remove_worktree
 
     if set -q _wclean_flag_dry_run
         printf "Would remove worktree: %s\n" $worktree_name
-        # Show branch deletion info
-        if test -n "$current_branch_name"; and not set -q _wclean_flag_no_delete_branch
-            printf "  Would also delete local branch: %s\n" $current_branch_name
-        else if set -q _wclean_flag_no_delete_branch
-            printf "  Would keep local branch: %s\n" $current_branch_name
+        # Show branch deletion info (only when the worktree has a branch, i.e.
+        # not a detached HEAD).
+        if test -n "$current_branch_name"
+            if not set -q _wclean_flag_no_delete_branch
+                printf "  Would also delete local branch: %s\n" $current_branch_name
+            else
+                printf "  Would keep local branch: %s\n" $current_branch_name
+            end
         end
     else
         if git worktree remove --force "$worktree_name" >/dev/null 2>&1

--- a/functions/git-wclean.fish
+++ b/functions/git-wclean.fish
@@ -17,6 +17,11 @@ function _wclean_cleanup_handler
     set -e _wclean_default_branch
     set -e _wclean_original_dir
 
+    # Clean up promoted argparse flags
+    set -e _wclean_flag_dry_run
+    set -e _wclean_flag_force
+    set -e _wclean_flag_no_delete_branch
+
     # Clean up config variables
     set -e _wclean_config_protected_branches
     set -e _wclean_config_default_upstream
@@ -55,6 +60,11 @@ function _wclean_normal_cleanup
     set -e _wclean_default_branch
     set -e _wclean_original_dir
 
+    # Clean up promoted argparse flags
+    set -e _wclean_flag_dry_run
+    set -e _wclean_flag_force
+    set -e _wclean_flag_no_delete_branch
+
     # Clean up config variables
     set -e _wclean_config_protected_branches
     set -e _wclean_config_default_upstream
@@ -67,7 +77,9 @@ end
 function _wclean_load_config
     # Set default configuration values
     set -g _wclean_config_protected_branches main master develop trunk
-    set -g _wclean_config_default_upstream origin/main
+    # Empty by default: the integration branch is auto-detected from origin/HEAD.
+    # Set this in a config file ONLY to override that detection explicitly.
+    set -g _wclean_config_default_upstream ""
     set -g _wclean_config_system_dirs /etc /bin /usr/bin /sbin /usr/sbin
     set -g _wclean_config_max_path_length 4096
     set -g _wclean_config_fetch_timeout 30
@@ -145,6 +157,16 @@ function _wclean_parse_args
         return 1
     end
 
+    # argparse populates _flag_* only in THIS function's local scope. The helper
+    # functions run in separate scopes and cannot see those locals, so promote
+    # the flags they need to globals (cleaned up in the cleanup handlers).
+    set -e _wclean_flag_dry_run
+    set -e _wclean_flag_force
+    set -e _wclean_flag_no_delete_branch
+    set -q _flag_dry_run; and set -g _wclean_flag_dry_run
+    set -q _flag_force; and set -g _wclean_flag_force
+    set -q _flag_no_delete_branch; and set -g _wclean_flag_no_delete_branch
+
     # Set the global worktrees directory
     set -g _wclean_worktrees_dir $argv[1]
     return 0
@@ -197,14 +219,14 @@ function _wclean_setup_directory
     end
 
     # Security validation: Ensure we have write permissions if not in dry-run mode
-    if not set -q _flag_dry_run; and not test -w "$_wclean_worktrees_dir"
+    if not set -q _wclean_flag_dry_run; and not test -w "$_wclean_worktrees_dir"
         printf "Error: No write permission for directory '%s'. Use --dry-run to preview.\n" $_wclean_worktrees_dir >&2
         return 1
     end
 
     printf "Scanning worktrees in: %s\n" $_wclean_worktrees_dir
 
-    if set -q _flag_dry_run
+    if set -q _wclean_flag_dry_run
         printf "DRY-RUN MODE: No worktrees will actually be removed.\n\n"
     end
     return 0
@@ -221,15 +243,34 @@ function _wclean_fetch_remotes
         set -g _wclean_remotes ""
     end
 
-    # Try to fetch from origin if it exists (with timeout)
+    # Try to fetch from origin if it exists. Guard the fetch with a timeout
+    # utility when one is available (`timeout` on Linux, `gtimeout` from GNU
+    # coreutils on macOS); otherwise fetch without a timeout rather than failing
+    # on the missing command.
     if contains origin $_wclean_remotes
-        printf "Fetching from origin (timeout: %ds)...\n" $_wclean_config_fetch_timeout
-        if timeout $_wclean_config_fetch_timeout git fetch origin >/dev/null 2>&1
-            printf "✓ Fetched from origin\n"
+        set -l timeout_cmd
+        if command -q timeout
+            set timeout_cmd timeout
+        else if command -q gtimeout
+            set timeout_cmd gtimeout
+        end
+
+        if test -n "$timeout_cmd"
+            printf "Fetching from origin (timeout: %ds)...\n" $_wclean_config_fetch_timeout
+            if $timeout_cmd $_wclean_config_fetch_timeout git fetch origin >/dev/null 2>&1
+                printf "✓ Fetched from origin\n"
+            else
+                set -l fetch_status $status
+                if test $fetch_status -eq 124 # timeout exit code
+                    printf "⚠️  Warning: Fetch from origin timed out after %ds. Proceeding with local information.\n" $_wclean_config_fetch_timeout
+                else
+                    printf "⚠️  Warning: Failed to fetch from origin. Proceeding with local information.\n"
+                end
+            end
         else
-            set -l fetch_status $status
-            if test $fetch_status -eq 124 # timeout exit code
-                printf "⚠️  Warning: Fetch from origin timed out after %ds. Proceeding with local information.\n" $_wclean_config_fetch_timeout
+            printf "Fetching from origin (no timeout utility found)...\n"
+            if git fetch origin >/dev/null 2>&1
+                printf "✓ Fetched from origin\n"
             else
                 printf "⚠️  Warning: Failed to fetch from origin. Proceeding with local information.\n"
             end
@@ -238,10 +279,20 @@ function _wclean_fetch_remotes
         printf "⚠️  Note: No 'origin' remote found.\n"
     end
 
-    # Cache default branch information for better performance
+    # Determine the integration branch from origin/HEAD. An explicit config
+    # override takes precedence; otherwise require origin/HEAD rather than
+    # silently assuming origin/main, which could delete unmerged work.
     set -g _wclean_default_branch (git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | string replace 'refs/remotes/' '')
-    if test $status -ne 0; or test -z "$_wclean_default_branch"
-        set -g _wclean_default_branch $_wclean_config_default_upstream
+    if test -z "$_wclean_default_branch"
+        if test -n "$_wclean_config_default_upstream"
+            set -g _wclean_default_branch $_wclean_config_default_upstream
+        else
+            printf "Error: Cannot determine the default branch — 'origin/HEAD' is not set.\n" >&2
+            printf "Set it (and retry) with:\n" >&2
+            printf "    git remote set-head origin --auto\n" >&2
+            printf "Or set _wclean_config_default_upstream in your git-wclean config.\n" >&2
+            return 1
+        end
     end
 
     printf "\n"
@@ -314,15 +365,12 @@ function _wclean_get_worktree_info
         set current_branch_name ""
     end
 
-    # Determine the upstream branch
-    set -l upstream_branch (git -C "$worktree_path" rev-parse --abbrev-ref '@{upstream}' 2>/dev/null)
-    if test $status -ne 0
-        # Use cached default branch instead of hardcoded origin/main
-        set upstream_branch $_wclean_default_branch
-        printf "  No upstream branch configured, using %s as default.\n" $upstream_branch
-    else
-        printf "  Upstream branch: %s\n" $upstream_branch
-    end
+    # Verify against the upstream project's default branch (origin/HEAD, cached
+    # in _wclean_default_branch), NOT the worktree branch's own remote-tracking
+    # branch (@{upstream}) — a feature branch pushed to origin/<feature> would
+    # always "match" itself and defeat the merge check.
+    set -l upstream_branch $_wclean_default_branch
+    printf "  Integration branch: %s\n" $upstream_branch
 
     # Export results as global variables for the caller
     set -g _wclean_head_commit $head_commit
@@ -407,7 +455,7 @@ function _wclean_remove_worktree
     set -l worktree_name (basename $worktree_path)
 
     # Protect main worktrees from accidental removal (unless --force is used)
-    if contains "$worktree_name" $_wclean_config_protected_branches; and not set -q _flag_force
+    if contains "$worktree_name" $_wclean_config_protected_branches; and not set -q _wclean_flag_force
         printf "  Protected: '%s' worktree will not be removed for safety.\n" $worktree_name
         return 1
     end
@@ -428,12 +476,12 @@ function _wclean_remove_worktree
         return 1
     end
 
-    if set -q _flag_dry_run
+    if set -q _wclean_flag_dry_run
         printf "Would remove worktree: %s\n" $worktree_name
         # Show branch deletion info
-        if test -n "$current_branch_name"; and not set -q _flag_no_delete_branch
+        if test -n "$current_branch_name"; and not set -q _wclean_flag_no_delete_branch
             printf "  Would also delete local branch: %s\n" $current_branch_name
-        else if set -q _flag_no_delete_branch
+        else if set -q _wclean_flag_no_delete_branch
             printf "  Would keep local branch: %s\n" $current_branch_name
         end
     else
@@ -441,7 +489,7 @@ function _wclean_remove_worktree
             printf "Removed worktree: %s\n" $worktree_name
 
             # Remove the associated local branch unless --no-delete-branch is specified
-            if test -n "$current_branch_name"; and not set -q _flag_no_delete_branch
+            if test -n "$current_branch_name"; and not set -q _wclean_flag_no_delete_branch
                 _wclean_remove_branch "$current_branch_name"
             else if test -n "$current_branch_name"
                 printf "  Keeping local branch '%s' as requested.\n" $current_branch_name
@@ -575,7 +623,7 @@ function _wclean_show_summary
 
     printf "\nSummary:\n"
     printf "  Processed: %d worktrees\n" $processed_count
-    if set -q _flag_dry_run
+    if set -q _wclean_flag_dry_run
         printf "  Would remove: %d worktrees\n" $removed_count
     else
         printf "  Removed: %d worktrees\n" $removed_count
@@ -594,15 +642,16 @@ function git-wclean --description "Clean up git worktrees that have been merged 
     #
     # DESCRIPTION
     #   This command scans a directory containing git worktrees and removes any worktrees
-    #   whose current HEAD commit has been merged into the upstream branch (typically
-    #   origin/main). This helps keep your worktree directory clean by automatically
-    #   removing branches that have been merged.
+    #   whose current HEAD commit has been merged into the upstream project's default
+    #   branch (origin/HEAD, e.g. origin/main or origin/master). This helps keep your
+    #   worktree directory clean by automatically removing branches that have been merged.
     #
     #   The command will:
     #   1. Scan each worktree in the specified directory
-    #   2. Determine the upstream branch (falls back to origin/main if not set)
+    #   2. Determine the integration branch from origin/HEAD (errors if it is unset,
+    #      unless overridden via _wclean_config_default_upstream)
     #   3. Fetch the latest changes from the remote
-    #   4. Check if the current HEAD commit exists in the upstream branch
+    #   4. Check if the current HEAD commit is merged into the integration branch
     #   5. Remove worktrees only if their commits have been merged
     #
     # OPTIONS
@@ -637,7 +686,8 @@ function git-wclean --description "Clean up git worktrees that have been merged 
     #   # Protected branch names (space-separated)
     #   set -g _wclean_config_protected_branches main master develop staging trunk
     #
-    #   # Default upstream branch when none is configured
+    #   # Override the integration branch (default: auto-detect from origin/HEAD).
+    #   # Only set this if origin/HEAD cannot be used.
     #   set -g _wclean_config_default_upstream origin/main
     #
     #   # System directories to protect (space-separated)
@@ -677,8 +727,11 @@ function git-wclean --description "Clean up git worktrees that have been merged 
         return 1
     end
 
-    # Fetch remote updates
-    _wclean_fetch_remotes
+    # Fetch remote updates and determine the integration branch
+    if not _wclean_fetch_remotes
+        _wclean_normal_cleanup
+        return 2
+    end
 
     # Track statistics
     set -l processed_count 0

--- a/functions/git-wrm.fish
+++ b/functions/git-wrm.fish
@@ -7,14 +7,16 @@ function git-wrm --description "Remove a git worktree after verifying commits ar
     #
     # DESCRIPTION
     #   This command removes a git worktree after verifying that its current HEAD commit
-    #   has been merged into the upstream branch (typically origin/main). This provides
-    #   a safe way to remove worktrees without losing any unmerged work.
+    #   has been merged into the upstream project's default branch (origin/HEAD, e.g.
+    #   origin/main or origin/master). This provides a safe way to remove worktrees
+    #   without losing any unmerged work.
     #
     #   The command will:
     #   1. Verify the worktree exists and is a valid git repository
-    #   2. Determine the upstream branch (falls back to origin/main if not set)
+    #   2. Determine the integration branch from origin/HEAD (errors if it is unset;
+    #      run 'git remote set-head origin --auto' to set it)
     #   3. Fetch the latest changes from the remote
-    #   4. Check if the current HEAD commit exists in the upstream branch
+    #   4. Check if the current HEAD commit is merged into the integration branch
     #   5. Remove the worktree only if the commit has been merged
     #
     # OPTIONS
@@ -170,33 +172,48 @@ function git-wrm --description "Remove a git worktree after verifying commits ar
         return 1
     end
 
-    # Determine the upstream branch
-    set -l upstream_branch (git rev-parse --abbrev-ref '@{upstream}' 2>/dev/null)
-    if test $status -ne 0
-        printf "  No upstream branch configured, using origin/main as default.\n"
-        set upstream_branch origin/main
-    else
-        printf "  Upstream branch: %s\n" $upstream_branch
+    # Determine the integration branch to verify against: the upstream
+    # project's default branch (origin/HEAD, e.g. origin/main or origin/master).
+    # This is deliberately NOT the worktree branch's own remote-tracking branch
+    # (@{upstream}) — a feature branch pushed to origin/<feature> would always
+    # "match" itself and defeat the merge check.
+    #
+    # Require origin/HEAD rather than silently assuming origin/main: guessing
+    # the wrong branch would make the merge check meaningless and risk deleting
+    # unmerged work.
+    set -l upstream_branch (git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | string replace 'refs/remotes/' '')
+    if test -z "$upstream_branch"
+        printf "Error: Cannot determine the default branch — 'origin/HEAD' is not set.\n" >&2
+        printf "Set it (and retry) with:\n" >&2
+        printf "    git remote set-head origin --auto\n" >&2
+        popd >/dev/null
+        return 2
     end
+    printf "  Integration branch: %s\n" $upstream_branch
 
-    # Extract remote name from upstream branch
+    # Extract remote name from the integration branch
     set -l remote_name (string split '/' $upstream_branch)[1]
     set -l branch_name (string join '/' (string split '/' $upstream_branch)[2..-1])
 
-    # Fetch latest from the remote
+    # Fetch latest from the remote so the merge check uses up-to-date refs
     printf "  Fetching latest from %s...\n" $remote_name
     if not git fetch $remote_name $branch_name >/dev/null 2>&1
         printf "  Warning: Failed to fetch from %s. Proceeding with local information.\n" $remote_name
     end
 
-    # Check if the commit exists in the upstream branch
+    # Check whether HEAD is already contained in the integration branch.
+    # rev-list lists commits reachable from HEAD but not from the integration
+    # branch; empty output means HEAD is fully merged. A rev-list error must
+    # NOT be treated as "merged", or the safety check becomes a no-op.
     set -l commit_found false
-    set -l branch_commits (git rev-list $head_commit --not $upstream_branch ^-1 2>/dev/null)
-    if test -z "$branch_commits"
+    set -l branch_commits (git rev-list $head_commit --not $upstream_branch 2>/dev/null)
+    if test $status -ne 0
+        printf "  ✗ Failed to check merge status against %s.\n" $upstream_branch >&2
+    else if test -z "$branch_commits"
         set commit_found true
-        printf "  ✓ Commit found in upstream branch %s.\n" $upstream_branch
+        printf "  ✓ Commit is merged into %s.\n" $upstream_branch
     else
-        printf "  ✗ Commit NOT found in upstream branch %s.\n" $upstream_branch
+        printf "  ✗ Commit NOT merged into %s.\n" $upstream_branch
     end
 
     popd >/dev/null

--- a/functions/git-wrm.fish
+++ b/functions/git-wrm.fish
@@ -195,10 +195,26 @@ function git-wrm --description "Remove a git worktree after verifying commits ar
     set -l remote_name (string split '/' $upstream_branch)[1]
     set -l branch_name (string join '/' (string split '/' $upstream_branch)[2..-1])
 
-    # Fetch latest from the remote so the merge check uses up-to-date refs
+    # Fetch latest from the remote so the merge check uses up-to-date refs.
+    # Guard against a slow, unreachable, or interactive remote with a timeout
+    # utility when available (`timeout` on Linux, `gtimeout` from GNU coreutils
+    # on macOS); otherwise fetch without a guard rather than failing.
+    set -l fetch_timeout 30
+    set -l timeout_cmd
+    if command -q timeout
+        set timeout_cmd timeout
+    else if command -q gtimeout
+        set timeout_cmd gtimeout
+    end
     printf "  Fetching latest from %s...\n" $remote_name
-    if not git fetch $remote_name $branch_name >/dev/null 2>&1
-        printf "  Warning: Failed to fetch from %s. Proceeding with local information.\n" $remote_name
+    if test -n "$timeout_cmd"
+        if not $timeout_cmd $fetch_timeout git fetch $remote_name $branch_name >/dev/null 2>&1
+            printf "  Warning: Failed to fetch from %s. Proceeding with local information.\n" $remote_name
+        end
+    else
+        if not git fetch $remote_name $branch_name >/dev/null 2>&1
+            printf "  Warning: Failed to fetch from %s. Proceeding with local information.\n" $remote_name
+        end
     end
 
     # Check whether HEAD is already contained in the integration branch.

--- a/tests/functional-tests.fish
+++ b/tests/functional-tests.fish
@@ -251,6 +251,180 @@ function test_git_wrm_validation --description "Test git-wrm input validation an
     return $failed_tests
 end
 
+function test_git_wrm_merge_check --description "Test git-wrm only removes worktrees merged into the default branch"
+    # Use environment variable or fall back to relative path
+    set -l test_functions_dir "$FISH_FUNCTIONS_DIR"
+    if test -z "$test_functions_dir"
+        set -l test_file_dir (dirname (status --current-filename))
+        set test_functions_dir "$test_file_dir/../functions"
+        if test -d "$test_functions_dir"
+            set test_functions_dir (realpath "$test_functions_dir")
+        end
+    end
+    set -l failed_tests 0
+    set -l total_tests 0
+
+    echo "🔍 Testing git-wrm merge verification..."
+
+    if not test -f "$test_functions_dir/git-wrm.fish"
+        echo "❌ git-wrm.fish not found in: $test_functions_dir"
+        return 1
+    end
+    source $test_functions_dir/git-wrm.fish
+
+    # Build a bare "remote" with a main branch
+    set -l remote_dir /tmp/git-fish-wrm-remote-(random).git
+    set -l main_dir /tmp/git-fish-wrm-main-(random)
+    rm -rf "$remote_dir" "$main_dir"
+    git init --bare -b main "$remote_dir" >/dev/null 2>&1
+
+    git clone "$remote_dir" "$main_dir" >/dev/null 2>&1
+    git -C "$main_dir" config user.name "Test User"
+    git -C "$main_dir" config user.email "test@example.com"
+    echo "# Test" > "$main_dir/README.md"
+    git -C "$main_dir" add README.md
+    git -C "$main_dir" commit -m "Initial commit" >/dev/null 2>&1
+    git -C "$main_dir" push -u origin main >/dev/null 2>&1
+    git -C "$main_dir" remote set-head origin main >/dev/null 2>&1
+
+    # Create a feature worktree with a commit pushed to its OWN remote branch
+    # (origin/feature) but never merged into origin/main. This is the exact
+    # scenario that the @{upstream} bug mishandled.
+    set -l feature_wt /tmp/git-fish-wrm-feature-(random)
+    rm -rf "$feature_wt"
+    git -C "$main_dir" worktree add -b feature "$feature_wt" >/dev/null 2>&1
+    echo "feature work" > "$feature_wt/feature.txt"
+    git -C "$feature_wt" add feature.txt
+    git -C "$feature_wt" commit -m "Unmerged feature work" >/dev/null 2>&1
+    git -C "$feature_wt" push -u origin feature >/dev/null 2>&1
+
+    # Test 1: refuses to remove a worktree not merged into origin/main
+    echo "Test 1: git-wrm refuses unmerged worktree..."
+    set total_tests (math $total_tests + 1)
+    git-wrm "$feature_wt" >/dev/null 2>&1
+    set -l rm_status $status
+    if test $rm_status -eq 3; and test -d "$feature_wt"
+        echo "✅ git-wrm refused to remove unmerged worktree (exit 3)"
+    else
+        echo "❌ git-wrm should refuse unmerged worktree: exit=$rm_status"
+        set failed_tests (math $failed_tests + 1)
+    end
+
+    # Merge the feature work into origin/main; now it should be removable.
+    git -C "$main_dir" merge --no-ff feature -m "Merge feature" >/dev/null 2>&1
+    git -C "$main_dir" push origin main >/dev/null 2>&1
+
+    # Test 2: dry-run reports it WOULD remove once merged into origin/main
+    echo "Test 2: git-wrm allows merged worktree..."
+    set total_tests (math $total_tests + 1)
+    set -l dry_output (git-wrm --dry-run "$feature_wt" 2>&1)
+    set -l dry_status $status
+    if test $dry_status -eq 0; and string match -q '*Would remove*' "$dry_output"
+        echo "✅ git-wrm recognizes merged worktree (dry-run would remove)"
+    else
+        echo "❌ git-wrm should allow merged worktree: exit=$dry_status"
+        set failed_tests (math $failed_tests + 1)
+    end
+
+    # Test 3: fails with guidance when origin/HEAD is not set, instead of
+    # silently assuming origin/main (which could delete unmerged work).
+    echo "Test 3: git-wrm errors when origin/HEAD is unset..."
+    set total_tests (math $total_tests + 1)
+    git -C "$main_dir" symbolic-ref --delete refs/remotes/origin/HEAD >/dev/null 2>&1
+    set -l noref_output (git-wrm "$feature_wt" 2>&1)
+    set -l noref_status $status
+    if test $noref_status -eq 2; and test -d "$feature_wt"; and string match -q '*origin/HEAD*' "$noref_output"
+        echo "✅ git-wrm errors with guidance when origin/HEAD is unset (exit 2)"
+    else
+        echo "❌ git-wrm should error when origin/HEAD is unset: exit=$noref_status"
+        set failed_tests (math $failed_tests + 1)
+    end
+
+    # Cleanup
+    git -C "$main_dir" worktree remove --force "$feature_wt" >/dev/null 2>&1
+    rm -rf "$remote_dir" "$main_dir" "$feature_wt"
+
+    echo "📊 git-wrm merge check results: $failed_tests/$total_tests failed"
+    return $failed_tests
+end
+
+function test_git_wclean_dry_run --description "Test git-wclean honors --dry-run and removes merged worktrees"
+    # Use environment variable or fall back to relative path
+    set -l test_functions_dir "$FISH_FUNCTIONS_DIR"
+    if test -z "$test_functions_dir"
+        set -l test_file_dir (dirname (status --current-filename))
+        set test_functions_dir "$test_file_dir/../functions"
+        if test -d "$test_functions_dir"
+            set test_functions_dir (realpath "$test_functions_dir")
+        end
+    end
+    set -l failed_tests 0
+    set -l total_tests 0
+
+    echo "🔍 Testing git-wclean --dry-run safety..."
+
+    if not test -f "$test_functions_dir/git-wclean.fish"
+        echo "❌ git-wclean.fish not found in: $test_functions_dir"
+        return 1
+    end
+    source $test_functions_dir/git-wclean.fish
+
+    # Build a bare "remote" with a main branch and a worktrees directory
+    set -l remote_dir /tmp/git-fish-wclean-remote-(random).git
+    set -l main_dir /tmp/git-fish-wclean-main-(random)
+    set -l wts_dir /tmp/git-fish-wclean-wts-(random)
+    rm -rf "$remote_dir" "$main_dir" "$wts_dir"
+    git init --bare -b main "$remote_dir" >/dev/null 2>&1
+    git clone "$remote_dir" "$main_dir" >/dev/null 2>&1
+    git -C "$main_dir" config user.name "Test User"
+    git -C "$main_dir" config user.email "test@example.com"
+    echo "# Test" > "$main_dir/README.md"
+    git -C "$main_dir" add README.md
+    git -C "$main_dir" commit -m "Initial commit" >/dev/null 2>&1
+    git -C "$main_dir" push -u origin main >/dev/null 2>&1
+    git -C "$main_dir" remote set-head origin main >/dev/null 2>&1
+
+    # A merged worktree: a new branch pointing at main's HEAD (contained in
+    # origin/main), so it is eligible for removal.
+    mkdir -p "$wts_dir"
+    git -C "$main_dir" worktree add "$wts_dir/merged" -b merged-copy >/dev/null 2>&1
+
+    # git-wclean detects the remote/default branch from the current repo, so
+    # run it from inside the repo (as documented usage implies).
+    set -l orig_dir (pwd)
+    cd "$main_dir"
+
+    # Test 1: --dry-run must NOT delete the worktree
+    echo "Test 1: git-wclean --dry-run keeps worktrees..."
+    set total_tests (math $total_tests + 1)
+    set -l dry_output (git-wclean --dry-run "$wts_dir" 2>&1)
+    if test -d "$wts_dir/merged"; and string match -q '*Would remove*' "$dry_output"
+        echo "✅ git-wclean --dry-run left the worktree in place"
+    else
+        echo "❌ git-wclean --dry-run should not delete the worktree"
+        set failed_tests (math $failed_tests + 1)
+    end
+
+    # Test 2: a real run removes the merged worktree
+    echo "Test 2: git-wclean removes merged worktree..."
+    set total_tests (math $total_tests + 1)
+    git-wclean "$wts_dir" >/dev/null 2>&1
+    if not test -d "$wts_dir/merged"
+        echo "✅ git-wclean removed the merged worktree"
+    else
+        echo "❌ git-wclean should have removed the merged worktree"
+        set failed_tests (math $failed_tests + 1)
+    end
+
+    # Cleanup
+    cd "$orig_dir"
+    git -C "$main_dir" worktree prune >/dev/null 2>&1
+    rm -rf "$remote_dir" "$main_dir" "$wts_dir"
+
+    echo "📊 git-wclean dry-run results: $failed_tests/$total_tests failed"
+    return $failed_tests
+end
+
 function run_functional_tests --description "Run all functional tests"
     set -l total_failed 0
 
@@ -268,6 +442,16 @@ function run_functional_tests --description "Run all functional tests"
     echo ""
 
     test_git_wrm_validation
+    set total_failed (math $total_failed + $status)
+
+    echo ""
+
+    test_git_wrm_merge_check
+    set total_failed (math $total_failed + $status)
+
+    echo ""
+
+    test_git_wclean_dry_run
     set total_failed (math $total_failed + $status)
 
     echo ""


### PR DESCRIPTION
## Problem

`git wrm` / `git wclean` are supposed to only remove a worktree once its commits have landed on the upstream project's default branch. They didn't — a worktree could be deleted with unmerged work.

## Root causes

**git-wrm**
- Compared `HEAD` against the branch's own tracking branch (`@{upstream}`, e.g. `origin/<feature>`), which trivially matches after a push and defeats the check.
- A stray invalid `^-1` in the `rev-list` check made it `fatal: bad revision`. With stderr sent to `/dev/null` and no exit-status check, the empty output was read as "merged", so removal **always** proceeded.

**git-wclean**
- Same `@{upstream}` vs default-branch issue (the correct branch was computed but only used as a fallback).
- `--dry-run`, `--force`, `--no-delete-branch` were silently ignored: `argparse` set `_flag_*` locally in a helper function, invisible to the other helpers (fish doesn't share locals across function calls). `--dry-run` therefore **deleted** worktrees.
- Hard dependency on `timeout` broke fetches on macOS (`Unknown command: timeout`).

## Fixes
- Verify against the project's default branch via `git symbolic-ref refs/remotes/origin/HEAD`; removed the `^-1` and now check `rev-list`'s exit status.
- Require `origin/HEAD` and fail with guidance (`git remote set-head origin --auto`) rather than silently assuming `origin/main`.
- Promote git-wclean's argparse flags to globals the helpers can read (cleaned up on exit/interrupt).
- Prefer `timeout`, fall back to `gtimeout`, then an unguarded fetch.

## Tests
Added functional coverage: `git-wrm` refuses unmerged worktrees, allows merged ones, and errors when `origin/HEAD` is unset; `git-wclean` honours `--dry-run` and removes merged worktrees. Full suite (syntax + formatting + functional) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Worktree cleanup now derives the integration/default branch from `origin/HEAD` (with config override).
  * Fetch operations use a timeout guard when available.
  * Dry-run output now more consistently reflects whether removal would occur.

* **Bug Fixes**
  * Worktree removal safety checks were updated to reliably validate merge status against the integration branch.
  * Cleanup now fails with clear guidance when `origin/HEAD` is unavailable, and stops appropriately when remote fetching fails.

* **Tests**
  * Added functional coverage for merged vs unmerged worktrees, missing `origin/HEAD`, and dry-run behavior for both commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->